### PR TITLE
test: add openChannel tests

### DIFF
--- a/contracts/MerkleOrchard.sol
+++ b/contracts/MerkleOrchard.sol
@@ -33,7 +33,7 @@ contract MerkleOrchard is ERC721Enumerable {
     }
 
     function openChannel() external {
-        _mint(msg.sender, channels.length);
+        _mint(msg.sender, totalSupply());
     }
 
     // TODO support ETH


### PR DESCRIPTION
Adds the `openChannel` tests. Noticed one issue: On opening a channel `channels.length` wasn't incremented, so clients weren't able to mint more item than 1.